### PR TITLE
Fix #6 - Use `os.lstat` instead of `os.stat` when listing directories

### DIFF
--- a/src/sftpserver/stub_sftp.py
+++ b/src/sftpserver/stub_sftp.py
@@ -74,7 +74,7 @@ class StubSFTPServer (SFTPServerInterface):
             out = []
             flist = os.listdir(path)
             for fname in flist:
-                attr = SFTPAttributes.from_stat(os.stat(os.path.join(path, fname)))
+                attr = SFTPAttributes.from_stat(os.lstat(os.path.join(path, fname)))
                 attr.filename = fname
                 out.append(attr)
             return out


### PR DESCRIPTION
This prevents incorrectly returning an error if one of the files in the
directory is a broken symlink.
